### PR TITLE
Change on requirements and small script for convenience of using venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fastapi
+fastapi[standard]
 faster_whisper
 torch

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -1,0 +1,43 @@
+@echo off
+setlocal
+
+:: Check if venv directory exists
+if not exist venv (
+    echo Virtual environment not found. Creating new environment...
+    python -m venv venv
+    
+    :: Check if venv creation was successful
+    if errorlevel 1 (
+        echo Failed to create virtual environment. Please check if Python is installed correctly.
+        pause
+        exit /b 1
+    )
+    
+    :: Activate the virtual environment
+    call venv\Scripts\activate
+    
+    :: Check if requirements.txt exists
+    if exist requirements.txt (
+        echo Installing requirements...
+        pip install -r requirements.txt
+        
+        if errorlevel 1 (
+            echo Failed to install requirements.
+            pause
+            exit /b 1
+        )
+    ) else (
+        echo Warning: requirements.txt not found. Skipping package installation.
+    )
+) else (
+    echo Virtual environment found. Activating...
+    call venv\Scripts\activate
+)
+
+:: Run FastAPI application
+echo Starting FastAPI application...
+fastapi run .\main.py
+
+:: Deactivate virtual environment on exit
+deactivate
+endlocal


### PR DESCRIPTION
Tried both on windows and docker and got the same runtime error asking me to install the "fastapi[standard]' instead of "fastapi" to able to use the fastapi run command.
And added this windows script to make it faster to clone and run the project